### PR TITLE
Add iframe provider polyfill so this tool can be used in Ethvault

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -27,5 +27,7 @@
       To begin the development, run `npm start`.
       To create a production bundle, use `npm run build`.
     -->
+    
+    <script src="https://unpkg.com/@ethvault/iframe-provider-polyfill@0.1.4/dist/index.js" integrity="sha384-MGEYVJJ9mpRbqHLuHyg9xjmzCG3WPS0XCWf0lNF07q1NN6WUPzBdDMW/6LRRBhxQ" crossorigin="anonymous"></script>
   </body>
 </html>


### PR DESCRIPTION
Add iframe provider polyfill so this tool can be used in Ethvault

This is particularly low risk for this tool because anyone can submit claims, so https://github.com/ethvault/iframe-provider-polyfill/issues/1 does not apply